### PR TITLE
Updating regex to match facebook's new url (ds)

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -19,6 +19,8 @@
   "content_scripts": [
     {
       "matches": [
+        "*://www.facebook.com/ads/preferences",
+        "*://www.facebook.com/ads/preferences/*",
         "*://www.facebook.com/ds/preferences",
         "*://www.facebook.com/ds/preferences/*"
       ],

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -19,8 +19,8 @@
   "content_scripts": [
     {
       "matches": [
-        "*://www.facebook.com/ads/preferences",
-        "*://www.facebook.com/ads/preferences/*"
+        "*://www.facebook.com/ds/preferences",
+        "*://www.facebook.com/ds/preferences/*"
       ],
       "js": [
         "scripts/facebook-ads-preferences-interests.js"


### PR DESCRIPTION
Facebook updated the url so people don't use this extension.
Ref: https://www.facebook.com/ds/preferences/